### PR TITLE
renaming config parameter to get all the same format styling (avoid camelCase)

### DIFF
--- a/browsertest.cfg.template
+++ b/browsertest.cfg.template
@@ -38,12 +38,11 @@ selenium_url = http://localhost:4444/wd/hub
 ## In this section you can add whatever capabilities you desire. If
 ## they are available in the driver you choose, they will be used.
 
-## There are some common capabilities, like "browserName" and
-## "javascriptEnabled". Check the Selenium documentation to see all of
+## There are some common capabilities, like "browser_name" and
+## "javascript_enabled". Check the Selenium documentation to see all of
 ## them.
 ## Defaults:
-##   browserName = firefox
-##   javascriptEnabled = True
-browserName = firefox
-javascriptEnabled = True
-
+##   browser_name = firefox
+##   javascript_enabled = True
+browser_name = firefox
+javascript_enabled = True

--- a/pybrowsertest/__init__.py
+++ b/pybrowsertest/__init__.py
@@ -49,8 +49,8 @@ class BrowserConfiguration(object):
     OPTION_SELENIUM_URL = 'selenium_url'
     OPTION_TESTING_URL = 'testing_url'
     OPTION_SCREENSHOT_PATTERN = 'screenshot_file_pattern'
-    OPTION_BROWSER_NAME = 'browserName'
-    OPTION_JAVASCRIPT = 'javascriptEnabled'
+    OPTION_BROWSER_NAME = 'browser_name'
+    OPTION_JAVASCRIPT = 'javascript_enabled'
 
     default_configuration_files = ['/etc/browsertest.cfg', '.browsertest.cfg', 'browsertest.cfg']
 
@@ -188,14 +188,14 @@ class BrowserTestCase(unittest.TestCase):
         return retval
 
 
-def onlyIfBrowserIn(*browserNames):
+def onlyIfBrowserIn(*browser_names):
     config = BrowserConfiguration()
     config.loadDefaultFiles()
     message = 'The test has been skipped for browser: {}'
-    return unittest.skipIf(config.browser_name not in browserNames, message.format(browserNames))
+    return unittest.skipIf(config.browser_name not in browser_names, message.format(browser_names))
 
-def onlyIfBrowserNotIn(*browserNames):
+def onlyIfBrowserNotIn(*browser_names):
     config = BrowserConfiguration()
     config.loadDefaultFiles()
     message = 'Current browser {} does not match any required browser for this test: {}'
-    return unittest.skipIf(config.browser_name in browserNames, message.format(config.browser_name, browserNames))
+    return unittest.skipIf(config.browser_name in browser_names, message.format(config.browser_name, browser_names))

--- a/run_tests.py
+++ b/run_tests.py
@@ -14,8 +14,8 @@ selenium_mode = ${selenium_mode}
 selenium_url = http://localhost:4444/wd/hub
 
 [desired capabilities]
-browserName = ${browser}
-javascriptEnabled = True
+browser_name = ${browser}
+javascript_enabled = True
 """
 
 class TestResultWrapper(unittest.TestResult):

--- a/test/integration_tests.py
+++ b/test/integration_tests.py
@@ -16,8 +16,8 @@ selenium_mode = ${selenium_mode}
 selenium_url = http://localhost:4444/wd/hub
 
 [desired capabilities]
-browserName = ${browser}
-javascriptEnabled = True
+browser_name = ${browser}
+javascript_enabled = True
 """
 
 


### PR DESCRIPTION
I'm going to revert it. The camelCase options are Selenium options and can be modified: http://selenium.googlecode.com/svn/trunk/docs/api/py/_modules/selenium/webdriver/common/desired_capabilities.html
So, the "Desired capabilities" section is defined by each Webdriver driver.
